### PR TITLE
Fix getopt usage

### DIFF
--- a/src/utils/machines.c
+++ b/src/utils/machines.c
@@ -58,7 +58,7 @@ int main(int argc, char * const argv[])
      size_t dlen = 0;
      int iret = 0;
      Machine machine, **ptr = machines;
-     char c;
+     int c;
      int also_dump_wrong = 0;
 
      while ((c = getopt(argc, argv, "c?")) != -1)

--- a/src/utils/s3gdump.c
+++ b/src/utils/s3gdump.c
@@ -36,11 +36,7 @@
 
 #include "s3g.h"
 
-#if defined(__arm__)
-#define GETOPTS_END (char)-1
-#else
 #define GETOPTS_END -1
-#endif
 
 static void usage(FILE *f, const char *prog)
 {
@@ -56,7 +52,7 @@ static void usage(FILE *f, const char *prog)
 
 int main(int argc, const char *argv[])
 {
-     char c;
+     int c;
      s3g_context_t *ctx;
      s3g_command_t cmd;
      int lineno, simple;


### PR DESCRIPTION
getopt() returns an int, not a char. Assigning the return value of
getopt() into a char causes gcc to hang while compiling gpx on some
architectures.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=818737
