### PR TITLE
Fix little-endian assumption

### DIFF
--- a/src/gpx/gpx.c
+++ b/src/gpx/gpx.c
@@ -34,6 +34,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <time.h>
+#include <stdint.h>
+#include <endian.h>
+
 #include <libgen.h>
 
 #include "gpx.h"
@@ -389,52 +392,52 @@ static unsigned char read_8(Gpx *gpx)
     return *gpx->buffer.ptr++;
 }
 
-static void write_16(Gpx *gpx, unsigned short value)
+static void write_16(Gpx *gpx, uint16_t value)
 {
     union {
-        unsigned short s;
+        uint16_t s;
         unsigned char b[2];
     } u;
-    u.s = value;
+    u.s = htole16(value);
     *gpx->buffer.ptr++ = u.b[0];
     *gpx->buffer.ptr++ = u.b[1];
 }
 
-static unsigned short read_16(Gpx *gpx)
+static uint16_t read_16(Gpx *gpx)
 {
     union {
-        unsigned short s;
+        uint16_t s;
         unsigned char b[2];
     } u;
     u.b[0] = *gpx->buffer.ptr++;
     u.b[1] = *gpx->buffer.ptr++;
-    return u.s;
+    return le16toh(u.s);
 }
 
-static void write_32(Gpx *gpx, unsigned int value)
+static void write_32(Gpx *gpx, uint32_t value)
 {
     union {
-        unsigned int i;
+        uint32_t i;
         unsigned char b[4];
     } u;
-    u.i = value;
+    u.i = htole32(value);
     *gpx->buffer.ptr++ = u.b[0];
     *gpx->buffer.ptr++ = u.b[1];
     *gpx->buffer.ptr++ = u.b[2];
     *gpx->buffer.ptr++ = u.b[3];
 }
 
-static unsigned int read_32(Gpx *gpx)
+static uint32_t read_32(Gpx *gpx)
 {
     union {
-        unsigned int i;
+        uint32_t i;
         unsigned char b[4];
     } u;
     u.b[0] = *gpx->buffer.ptr++;
     u.b[1] = *gpx->buffer.ptr++;
     u.b[2] = *gpx->buffer.ptr++;
     u.b[3] = *gpx->buffer.ptr++;
-    return u.i;
+    return le32toh(u.i);
 }
 
 static void write_fixed_16(Gpx *gpx, float value)
@@ -457,9 +460,11 @@ static void write_float(Gpx *gpx, float value)
 {
     union {
         float f;
+        uint32_t i;
         unsigned char b[4];
     } u;
     u.f = value;
+    u.i = htole32(u.i);
     *gpx->buffer.ptr++ = u.b[0];
     *gpx->buffer.ptr++ = u.b[1];
     *gpx->buffer.ptr++ = u.b[2];
@@ -470,12 +475,14 @@ static float read_float(Gpx *gpx)
 {
     union {
         float f;
+        uint32_t i;
         unsigned char b[4];
     } u;
     u.b[0] = *gpx->buffer.ptr++;
     u.b[1] = *gpx->buffer.ptr++;
     u.b[2] = *gpx->buffer.ptr++;
     u.b[3] = *gpx->buffer.ptr++;
+    u.i = le32toh(u.i);
     return u.f;
 }
 

--- a/src/shared/s3g.c
+++ b/src/shared/s3g.c
@@ -28,6 +28,7 @@
 #include <stdarg.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <endian.h>
 
 #include "s3g_private.h"
 #include "s3g_stdio.h"
@@ -375,6 +376,7 @@ int s3g_command_read_ext(s3g_context_t *ctx, s3g_command_t *cmd,
 	  memcpy(&f32.u.c, buf, 4); \
 	  buf    += bytes_read; \
 	  maxbuf -= bytes_read; \
+	  f32.u.u = le32toh(f32.u.u); \
 	  cmd->t.v = f32.u.i
 
 #define GET_UINT32(v) \
@@ -384,7 +386,7 @@ int s3g_command_read_ext(s3g_context_t *ctx, s3g_command_t *cmd,
 	  memcpy(&f32.u.c, buf, 4); \
 	  buf    += bytes_read; \
 	  maxbuf -= bytes_read; \
-	  cmd->t.v = f32.u.u
+	  cmd->t.v = le32toh(f32.u.u)
 
 #define GET_FLOAT32(v) \
 	  if (maxbuf < 4) goto trunc; \
@@ -393,6 +395,7 @@ int s3g_command_read_ext(s3g_context_t *ctx, s3g_command_t *cmd,
 	  memcpy(&f32.u.c, buf, 4); \
 	  buf    += bytes_read; \
 	  maxbuf -= bytes_read; \
+	  f32.u.u = le32toh(f32.u.u); \
 	  cmd->t.v = f32.u.f;
 
 #define GET_UINT8(v) \
@@ -411,6 +414,7 @@ int s3g_command_read_ext(s3g_context_t *ctx, s3g_command_t *cmd,
 	  memcpy(&f16.u.c, buf, 2); \
 	  buf    += bytes_read; \
 	  maxbuf -= bytes_read; \
+	  f16.u.u = le16toh(f16.u.u); \
 	  cmd->t.v = f16.u.i
 
 #define GET_UINT16(v) \
@@ -420,7 +424,7 @@ int s3g_command_read_ext(s3g_context_t *ctx, s3g_command_t *cmd,
 	  memcpy(&f16.u.c, buf, 2); \
 	  buf    += bytes_read; \
 	  maxbuf -= bytes_read; \
-	  cmd->t.v = f16.u.u
+	  cmd->t.v = le16toh(f16.u.u)
 
 #define ZERO(v,c) cmd->t.v = (c)0
 
@@ -483,9 +487,10 @@ int s3g_command_read_ext(s3g_context_t *ctx, s3g_command_t *cmd,
 
 	  if (cmd->t.tool.subcmd_len == 1)
 	       cmd->t.tool.subcmd_value = (uint16_t)buf[3];
-	  else if (cmd->t.tool.subcmd_len > 1)
+	  else if (cmd->t.tool.subcmd_len > 1) {
 	       memcpy((void *)&cmd->t.tool.subcmd_value, buf + 3, sizeof(uint16_t));
-	  else
+	       cmd->t.tool.subcmd_value = le16toh(cmd->t.tool.subcmd_value);
+	  } else
 	       cmd->t.tool.subcmd_value = 0;
 
 	  maxbuf -= 3 + bytes_read;


### PR DESCRIPTION
Fixes: #8

With this, gpx should work on big-endian machines without spitting reversed integers into the stream.
