### PR TITLE
Use double literal when calculating dda_rate

### DIFF
--- a/src/gpx/gpx.c
+++ b/src/gpx/gpx.c
@@ -2260,7 +2260,7 @@ static int queue_ext_point(Gpx *gpx, double feedrate, Ptr5d delta, int relative)
         Point5d steps = mm_to_steps(gpx, &target, &gpx->excess);
 
 	// Total time required for the motion in units of microseconds
-        double usec = (60000000.0 * minutes);
+        double usec = (60000000.0L * minutes);
 
 	// Time interval between steps along the axis with the highest step count
 	//   total-time / highest-step-count
@@ -2269,7 +2269,7 @@ static int queue_ext_point(Gpx *gpx, double feedrate, Ptr5d delta, int relative)
 
         // Convert dda_interval into dda_rate (dda steps per second on the longest axis)
 	// steps-per-microsecond * 1000000 us/s = 1000000 * (1 / dda_interval)
-        double dda_rate = 1000000.0 / dda_interval;
+        double dda_rate = 1000000.0L / dda_interval;
 
         gpx->accumulated.time += (minutes * 60) * ACCELERATION_TIME;
 


### PR DESCRIPTION
This fixes an issue where dda_rate gets calculated off-by-one when
compiled with -O2 on Debian i386:

``` diff
--- lint.txt    2016-04-13 21:56:39.645223310 +0800
+++ tests/lint.txt      2016-04-02 13:27:31.000000000 +0800
@@ -13,7 +13,7 @@
 12: (155) Move to (889, 889, 4000, -96, 0), DDA rate 3849, A, B relative, distance 34.641018 mm, feedrate*64 1066 steps/s
 13: (150) Set build percentage 1%, reserved 0
 14: (149) Display message, options 0x02, position (0, 0), timeout 0 s, message "G1 - coord move-f"
-15: (155) Move to (889, 889, 4000, -97, 0), DDA rate 2559, A, B relative, distance 1.000000 mm, feedrate*64 1706 steps/s
+15: (155) Move to (889, 889, 4000, -97, 0), DDA rate 2560, A, B relative, distance 1.000000 mm, feedrate*64 1706 steps/s
 16: (149) Display message, options 0x02, position (0, 0), timeout 0 s, message "G4 - dwell"
 17: (133) Dwell for 1000 milliseconds
 18: (149) Display message, options 0x02, position (0, 0), timeout 0 s, message "G10 - set offsets"
```
