### PR TITLE
Use <endian.h> on all __GLIBC__ platforms

### DIFF
--- a/src/shared/portable_endian.h
+++ b/src/shared/portable_endian.h
@@ -17,7 +17,7 @@
 
 #endif
 
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__GLIBC__)
 
 #	include <endian.h>
 


### PR DESCRIPTION
This includes kfreebsd-\* and hurd-\* which don't fall under `__linux__`.
