### PR TITLE
Fixed typo of "verose" to "verbose"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ sudo make install
 
 # Copyright
 
-Copyright (c) 2013 WHPThomas, All rights reserved.  
-Additional changes Copyright (c) 2014, 2015 DNewman, MWalker  
+Copyright (c) 2013 WHPThomas, All rights reserved.
+Additional changes Copyright (c) 2014, 2015 DNewman, MWalker
 All rights reserved.
 
 This program is free software; you can redistribute it and/or modify
@@ -90,7 +90,7 @@ Options:
 	-q	quiet mode
 	-r	Reprap GCODE flavor
 	-t	truncate filename (DOS 8.3 format)
-	-v	verose mode
+	-v	verbose mode
 	-w	rewrite 5d extrusion values
 CONFIG: the filename of a custom machine definition (ini file)
 EEPROM: the filename of an eeprom settings definition (ini file)

--- a/src/gpx/gpx-main.c
+++ b/src/gpx/gpx-main.c
@@ -156,7 +156,7 @@ static void usage(int err)
     fputs("\t-s\tenable USB serial I/O and send x3G output to 3D printer" EOL, fp);
 #endif
     fputs("\t-t\ttruncate filename (DOS 8.3 format)" EOL, fp);
-    fputs("\t-v\tverose mode" EOL, fp);
+    fputs("\t-v\tverbose mode" EOL, fp);
     fputs("\t-w\trewrite 5d extrusion values" EOL, fp);
 #if defined(SERIAL_SUPPORT)
     fputs(EOL "BAUDRATE: the baudrate for serial I/O (default is 115200)" EOL, fp);


### PR DESCRIPTION
Also my IDE accidentally automatically removed some trailing spaces.
Bonus?