### PR TITLE
Fix build on OSX when serial support is enabled

### DIFF
--- a/src/gpx/gpx.h
+++ b/src/gpx/gpx.h
@@ -39,6 +39,9 @@ extern "C" {
 
 #if defined(SERIAL_SUPPORT)
 #if !defined(_WIN32) && !defined(_WIN64)
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE
+#endif
 #include <termios.h>
 #else
 #include "winsio.h"


### PR DESCRIPTION
termios.h on osx/xnu does not define B115200 or B57000 unless _DARWIN_C_SOURCE is defined or _POSIX_C_SOURCE is undefined.
